### PR TITLE
Feature / Migrate the signing to schnorrkel.js lib v2

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,10 +1,24 @@
+const webpack = require("webpack");
+
 module.exports = {
   webpack: {
-    alias: {
-      crypto: require.resolve("crypto-browserify"),
-      buffer: require.resolve("buffer/"),
-      assert: require.resolve("assert/"),
-      stream: require.resolve("stream-browserify"),
+    configure: (webpackConfig) => {
+      // ProvidePlugin for Buffer
+      webpackConfig.plugins.push(
+        new webpack.ProvidePlugin({
+          Buffer: ["buffer", "Buffer"],
+        })
+      );
+
+      // Aliases for other modules
+      webpackConfig.resolve.alias = {
+        ...webpackConfig.resolve.alias,
+        crypto: require.resolve("crypto-browserify"),
+        stream: require.resolve("stream-browserify"),
+        assert: require.resolve("assert/"),
+      };
+
+      return webpackConfig;
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "qr-seal",
       "version": "0.1.0",
       "dependencies": {
-        "@borislav.itskov/schnorrkel.js": "1.0.2",
+        "@borislav.itskov/schnorrkel.js": "^2.0.4",
         "@craco/craco": "^7.1.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -2042,15 +2042,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@borislav.itskov/schnorrkel.js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@borislav.itskov/schnorrkel.js/-/schnorrkel.js-1.0.2.tgz",
-      "integrity": "sha512-InjDI3LY1q51l4oxAgN3v1RD1ojhE59mnH4zSdxjkO7Ysi1FnTQDiJB4fuGr22EJIm2MAaeI/DHwycMHDnUA6g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@borislav.itskov/schnorrkel.js/-/schnorrkel.js-2.0.4.tgz",
+      "integrity": "sha512-5gSkErSl6WrWm5KsVAeeliZTM65SrzPLOD51z2fMYvGBX3iBDqsEMApz9J/OL5HZHtX3WkPNQXP9pKDYAH9JFw==",
       "dependencies": {
         "bigi": "^1.4.2",
-        "crypto": "^1.0.1",
         "ecurve": "^1.0.6",
-        "ethers": "^5.7",
+        "ethers": "^5.7.2",
         "secp256k1": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0, <20.0.0"
       }
     },
     "node_modules/@craco/craco": {
@@ -6969,12 +6971,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.0",
@@ -20102,14 +20098,13 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@borislav.itskov/schnorrkel.js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@borislav.itskov/schnorrkel.js/-/schnorrkel.js-1.0.2.tgz",
-      "integrity": "sha512-InjDI3LY1q51l4oxAgN3v1RD1ojhE59mnH4zSdxjkO7Ysi1FnTQDiJB4fuGr22EJIm2MAaeI/DHwycMHDnUA6g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@borislav.itskov/schnorrkel.js/-/schnorrkel.js-2.0.4.tgz",
+      "integrity": "sha512-5gSkErSl6WrWm5KsVAeeliZTM65SrzPLOD51z2fMYvGBX3iBDqsEMApz9J/OL5HZHtX3WkPNQXP9pKDYAH9JFw==",
       "requires": {
         "bigi": "^1.4.2",
-        "crypto": "^1.0.1",
         "ecurve": "^1.0.6",
-        "ethers": "^5.7",
+        "ethers": "^5.7.2",
         "secp256k1": "^5.0.0"
       }
     },
@@ -23583,11 +23578,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "crypto-browserify": {
       "version": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@borislav.itskov/schnorrkel.js": "1.0.2",
+    "@borislav.itskov/schnorrkel.js": "^2.0.4",
     "@craco/craco": "^7.1.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/src/sign/Sign.tsx
+++ b/src/sign/Sign.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { utils } from "ethers";
-// TODO: Figure out why this import fails
-// import Schnorrkel from "@borislav.itskov/schnorrkel.js";
-const Schnorrkel = require("@borislav.itskov/schnorrkel.js");
-const schnorrkel = new Schnorrkel();
+import Schnorrkel, { Key } from "@borislav.itskov/schnorrkel.js";
 
 // TODO: That's temporarily
 const privateKey = utils.randomBytes(32);
@@ -16,11 +13,19 @@ const publicKey = utils.arrayify(
 
 const Sign: React.FC = () => {
   const handleClick = () => {
-    const { R, s } = schnorrkel.sign(msg, privateKey);
+    const { signature, finalPublicNonce } = Schnorrkel.sign(
+      new Key(Buffer.from(privateKey)),
+      msg
+    );
 
     console.log("publicKey", publicKey);
 
-    const isVerified = schnorrkel.verify(s, msg, R, publicKey);
+    const isVerified = Schnorrkel.verify(
+      signature,
+      msg,
+      finalPublicNonce,
+      new Key(Buffer.from(publicKey))
+    );
     console.log("Verified or not:", isVerified);
   };
 


### PR DESCRIPTION
Implements polyfill for the Buffer module (a bit different than the other ones, because using aliases wasn't the right way to make Buffer available globally.

Changes a bit the signing logic to fit the schnorrkel.js v2